### PR TITLE
Added command line options based on CommandLine library and updated for Bitbucket API 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+/.vs/BitToGithub/v16/Server/sqlite3

--- a/BitToGithub/App.config
+++ b/BitToGithub/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.3" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
 </configuration>

--- a/BitToGithub/BitBuckect.cs
+++ b/BitToGithub/BitBuckect.cs
@@ -1,103 +1,135 @@
-﻿using System;
+﻿// This file is part of the BitToGithub project
+//
+// Copyright © 2016-2019 Tigra Astronomy, all rights reserved.
+//
+// File: BitBuckect.cs  Last modified: 2019-09-06@06:47 by Tim Long
+
+using System;
 
 namespace BitToGithub
 {
-    public class BitBuckect
+    public class BitBucket
     {
-        public class Rootobject
+        public class Comment
         {
-            public int count { get; set; }
-            public Filter filter { get; set; }
-            public object search { get; set; }
-            public Issue[] issues { get; set; }
+            public Content content { get; set; }
+
+            public DateTime created_on { get; set; }
+
+            public int id { get; set; }
+
+            public Issue issue { get; set; }
+
+            public Links links { get; set; }
+
+            public string type { get; set; }
+
+            public DateTime? updated_on { get; set; }
+
+            public Person user { get; set; }
         }
 
-        public class Filter
+        public class CommentRoot
         {
+            public int page { get; set; }
+
+            public int pagelen { get; set; }
+
+            public int size { get; set; }
+
+            public Comment[] values { get; set; }
+            public string next { get; set; }
+            public string previous { get; set; }
+
+            }
+
+        public class Content
+        {
+            public string html { get; set; }
+
+            public string markup { get; set; }
+
+            public string raw { get; set; }
+
+            public string type { get; set; }
         }
 
         public class Issue
         {
-            public string status { get; set; }
-            public string priority { get; set; }
-            public string title { get; set; }
-            public Reported_By reported_by { get; set; }
-            public string utc_last_updated { get; set; }
-            public Responsible responsible { get; set; }
-            public DateTime created_on { get; set; }
-            public Metadata metadata { get; set; }
-            public string content { get; set; }
-            public int comment_count { get; set; }
-            public int local_id { get; set; }
-            public int follower_count { get; set; }
-            public string utc_created_on { get; set; }
-            public string resource_uri { get; set; }
-            public bool is_spam { get; set; }
-        }
+            public Person assignee { get; set; }
 
-        public class Reported_By
-        {
-            public string username { get; set; }
-            public string first_name { get; set; }
-            public string last_name { get; set; }
-            public string display_name { get; set; }
-            public bool is_staff { get; set; }
-            public string avatar { get; set; }
-            public string resource_uri { get; set; }
-            public bool is_team { get; set; }
-        }
-
-        public class Responsible
-        {
-            public string username { get; set; }
-            public string first_name { get; set; }
-            public string last_name { get; set; }
-            public string display_name { get; set; }
-            public bool is_staff { get; set; }
-            public string avatar { get; set; }
-            public string resource_uri { get; set; }
-            public bool is_team { get; set; }
-        }
-
-        public class Metadata
-        {
-            public string kind { get; set; }
-            public string version { get; set; }
             public string component { get; set; }
+
+            public Content content { get; set; }
+
+            public DateTime? created_on { get; set; }
+
+            public DateTime? edited_on { get; set; }
+
+            public int id { get; set; }
+
+            public string kind { get; set; }
+
+            public Links links { get; set; }
+
             public string milestone { get; set; }
+
+            public string priority { get; set; }
+
+            public Person reporter { get; set; }
+
+            public Repository repository { get; set; }
+
+            public string state { get; set; }
+
+            public string title { get; set; }
+
+            public string type { get; set; }
+
+            public DateTime? updated_on { get; set; }
+
+            public string version { get; set; }
+
+            public int votes { get; set; }
+
+            public int watches { get; set; }
         }
 
-    }
-
-    public class BitBucketComment
-    {
-        public class Rootobject
+        public class IssueRoot
         {
-            public Class1[] Property1 { get; set; }
+            public int page { get; set; }
+
+            public int pagelen { get; set; }
+
+            public int size { get; set; }
+
+            public Issue[] values { get; set; }
+
+            public string next { get; set; }
+            public string previous { get; set; }
         }
 
-        public class Class1
+        public class Links
         {
-            public string content { get; set; }
-            public Author_Info author_info { get; set; }
-            public int comment_id { get; set; }
-            public string utc_updated_on { get; set; }
-            public bool convert_markup { get; set; }
-            public string utc_created_on { get; set; }
-            public bool is_spam { get; set; }
         }
 
-        public class Author_Info
+        public class Person
         {
-            public string username { get; set; }
-            public string first_name { get; set; }
-            public string last_name { get; set; }
+            public string account_id { get; set; }
+
             public string display_name { get; set; }
-            public bool is_staff { get; set; }
-            public string avatar { get; set; }
-            public string resource_uri { get; set; }
-            public bool is_team { get; set; }
+
+            public Links links { get; set; }
+
+            public string nickname { get; set; }
+
+            public string type { get; set; }
+
+            public string uuid { get; set; }
         }
 
+        public class Repository
+        {
+        }
     }
 }

--- a/BitToGithub/BitToGithub.csproj
+++ b/BitToGithub/BitToGithub.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BitToGithub</RootNamespace>
     <AssemblyName>BitToGithub</AssemblyName>
-    <TargetFrameworkVersion>v4.5.3</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -62,6 +66,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BitBuckect.cs" />
+    <Compile Include="ExitCode.cs" />
+    <Compile Include="Helpers.cs" />
+    <Compile Include="IssueMigrator.cs" />
+    <Compile Include="MigrationOptions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/BitToGithub/BitToGithub.csproj.DotSettings
+++ b/BitToGithub/BitToGithub.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp80</s:String></wpf:ResourceDictionary>

--- a/BitToGithub/ExitCode.cs
+++ b/BitToGithub/ExitCode.cs
@@ -1,0 +1,14 @@
+﻿// This file is part of the BitToGithub project
+// 
+// Copyright © 2016-2019 Tigra Astronomy, all rights reserved.
+// 
+// File: ExitCode.cs  Last modified: 2019-09-06@02:40 by Tim Long
+namespace BitToGithub
+{
+    internal enum ExitCode
+    {
+        SignalSuccess = 0,
+        SignalMigrationFailed = -2,
+        SignalInvalidOptions = -1,
+    }
+}

--- a/BitToGithub/Helpers.cs
+++ b/BitToGithub/Helpers.cs
@@ -1,0 +1,50 @@
+﻿// This file is part of the BitToGithub project
+//
+// Copyright © 2016-2019 Tigra Astronomy, all rights reserved.
+//
+// File: Helpers.cs  Last modified: 2019-09-06@03:52 by Tim Long
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace BitToGithub
+{
+    internal static class Helpers
+    {
+        public static string Base64Encoded(this string value)
+        {
+            byte[] toEncodeAsBytes = Encoding.UTF8.GetBytes(value);
+            return Convert.ToBase64String(toEncodeAsBytes);
+        }
+
+        public static void WithErrors(this ExitCode code, IEnumerable<string> errors = null)
+        {
+            var errorsToReport = errors.ToList();
+            switch (code)
+            {
+                case ExitCode.SignalSuccess:
+                    Console.WriteLine("Completed successfully");
+                    break;
+                default:
+                    if (errorsToReport.Any())
+                    {
+                        Console.WriteLine($"Exiting with code {(int) code} ({code}) due to the following errors:");
+                        foreach (var error in errors)
+                        {
+                            Console.WriteLine(error);
+                        }
+                    }
+                    else
+                        Console.WriteLine($"Exiting with code {(int) code} ({code})");
+                    break;
+            }
+#if DEBUG
+            Console.WriteLine("Press <ENTER> to close the program...");
+            Console.ReadLine();
+#endif //DEBUG
+            Environment.Exit((int) code);
+        }
+    }
+}

--- a/BitToGithub/IssueMigrator.cs
+++ b/BitToGithub/IssueMigrator.cs
@@ -1,0 +1,166 @@
+﻿// This file is part of the BitToGithub project
+//
+// Copyright © 2016-2019 Tigra Astronomy, all rights reserved.
+//
+// File: IssueMigrator.cs  Last modified: 2019-09-06@06:53 by Tim Long
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit;
+using ProductHeaderValue = Octokit.ProductHeaderValue;
+
+namespace BitToGithub
+{
+    internal class IssueMigrator
+    {
+        private readonly List<string> closedIssueStates = new List<string> {"closed", "resolved", "invalid", "wontfix"};
+        private readonly MigrationOptions options;
+        private readonly string bitbucketRepoIssuesUrl;
+
+        public IssueMigrator(MigrationOptions options)
+        {
+            this.options = options;
+            bitbucketRepoIssuesUrl =
+                $"https://api.bitbucket.org/2.0/repositories/{options.bbRepoOwnerName}/{options.bbRepoName}/issues";
+        }
+
+        public async Task<ExitCode> Run()
+        {
+            var github = new GitHubClient(new ProductHeaderValue("bitbucket-issue-migrator"));
+            github.Credentials = new Credentials(options.githubUsername, options.githubPassword);
+            var repo = await github.Repository.Get(options.githubRepoOwnerName, options.githubRepoName);
+
+            using (HttpClient client = new HttpClient())
+            {
+                string authHeaderRaw = $"{options.bbUsername}:{options.bbPassword}";
+                AuthenticationHeaderValue authHeader =
+                    new AuthenticationHeaderValue("Basic", authHeaderRaw.Base64Encoded());
+                client.DefaultRequestHeaders.Authorization = authHeader;
+
+                // create the migration label.
+                try
+                {
+                    var label = await github.Issue.Labels.Get(
+                        options.githubRepoOwnerName,
+                        options.githubRepoName,
+                        options.LabelName);
+                }
+                catch (NotFoundException ex)
+                {
+                    // assume that the label is not there. create.
+                    var label = await github.Issue.Labels.Create(
+                        options.githubRepoOwnerName,
+                        options.githubRepoName,
+                        new NewLabel(options.LabelName, options.LabelColor));
+                }
+
+                int startIndex = 1;
+                var requestUrl = bitbucketRepoIssuesUrl;
+                while (!string.IsNullOrWhiteSpace(requestUrl))
+                {
+                    var response = await client.GetAsync($"{bitbucketRepoIssuesUrl}?start={startIndex}");
+                    response.EnsureSuccessStatusCode();
+                    var repoIssues = await response.Content.ReadAsAsync<BitBucket.IssueRoot>();
+                    startIndex += repoIssues.size;
+
+                    if (repoIssues.values.Length < 1)
+                        break;
+                    var bodyBuilder = new StringBuilder();
+                    foreach (var bitbucketIssue in repoIssues.values)
+                    {
+                        Console.WriteLine("found issue {0}", bitbucketIssue.id);
+                        var newIssue = new NewIssue(bitbucketIssue.title);
+                        newIssue.Labels.Add(options.LabelName);
+                        bodyBuilder.Clear()
+                            .AppendLine(bitbucketIssue.content.raw)
+                            .AppendLine()
+                            .Append($"> Originally created at {bitbucketIssue.created_on} ")
+                            .Append($"by {bitbucketIssue.reporter.display_name} ")
+                            .Append($"as a {bitbucketIssue.kind} with severity {bitbucketIssue.priority}.");
+                        newIssue.Body = bodyBuilder.ToString();
+                        if (!string.IsNullOrWhiteSpace(bitbucketIssue.component))
+                        {
+                            // Bitbucket Component --> GitHub Label
+                            try
+                            {
+                                var label = await github.Issue.Labels.Get(
+                                    options.githubRepoOwnerName,
+                                    options.githubRepoName,
+                                    bitbucketIssue.component);
+                            }
+                            catch (Exception ex)
+                            {
+                                // assume that the label is not there. create.
+                                Console.WriteLine("Creating label {0}", bitbucketIssue.component);
+                                var label = await github.Issue.Labels.Create(
+                                    options.githubRepoOwnerName,
+                                    options.githubRepoName,
+                                    new NewLabel(bitbucketIssue.component, options.ComponentColor));
+                            }
+                            newIssue.Labels.Add(bitbucketIssue.component);
+                        }
+
+                        // push the issue to GitHub
+                        Console.WriteLine($"Creating issue {bitbucketIssue.id} on GitHub");
+                        var githubIssue = await github.Issue.Create(
+                            options.githubRepoOwnerName,
+                            options.githubRepoName,
+                            newIssue);
+                        Console.WriteLine($"Created issue {githubIssue.Number} on github.");
+
+                        // Map issue states by closing the issue on GitHub
+                        if (closedIssueStates.Contains(bitbucketIssue.state, StringComparer.InvariantCultureIgnoreCase))
+                        {
+                            Console.WriteLine($"Closing resolved issue {githubIssue.Number} on github.");
+                            var updatedIssue = await github.Issue.Update(
+                                options.githubRepoOwnerName,
+                                options.githubRepoName, githubIssue.Number,
+                                new IssueUpdate
+                                    {
+                                        State = ItemState.Closed
+                                    });
+                        }
+                        await MigrateComments(client, bitbucketIssue, github, githubIssue);
+                    }
+                    requestUrl = repoIssues.next;
+                }
+            }
+            return ExitCode.SignalSuccess;
+        }
+
+        private async Task MigrateComments(HttpClient bitbuckeClient, BitBucket.Issue issue, GitHubClient github,
+            Issue githubIssue)
+        {
+            var pageUrl = $"{bitbucketRepoIssuesUrl}/{issue.id}/comments";
+            while (!string.IsNullOrWhiteSpace(pageUrl))
+            {
+                var commentsResponse = await bitbuckeClient.GetAsync($"{bitbucketRepoIssuesUrl}/{issue.id}/comments");
+                if (!commentsResponse.IsSuccessStatusCode)
+                {
+                    Console.WriteLine(
+                        $"Failed to fetch comments for Bitbucket issue {issue.id} - migration incomplete");
+                    return;
+                }
+                var commentRoot = await commentsResponse.Content.ReadAsAsync<BitBucket.CommentRoot>();
+                var commentCount = commentRoot.values.Length;
+                Console.WriteLine($"Found {commentCount} comments associated with issue {issue.id}");
+                if (commentCount < 1)
+                    return;
+                foreach (var comment in commentRoot.values)
+                {
+                    Console.WriteLine($"Adding comment {comment.id} for github issue {githubIssue.Number}.");
+                    var createdComment = await github.Issue.Comment.Create(
+                        options.githubRepoOwnerName,
+                        options.githubRepoName,
+                        githubIssue.Number, comment.content.raw ?? "Edited description");
+                }
+                pageUrl = commentRoot.next;
+            }
+        }
+    }
+}

--- a/BitToGithub/MigrationOptions.cs
+++ b/BitToGithub/MigrationOptions.cs
@@ -1,0 +1,36 @@
+﻿// This file is part of the BitToGithub project
+//
+// Copyright © 2016-2019 Tigra Astronomy, all rights reserved.
+//
+// File: MigrationOptions.cs  Last modified: 2019-09-06@00:02 by Tim Long
+
+using CommandLine;
+
+namespace BitToGithub
+{
+    class MigrationOptions
+    {
+        [Option('p',"bbPass", Required = true, HelpText = "Bitbucket login password")]
+        public string bbPassword { get; set; }
+        [Option('r',"bbRepo", Required = true, HelpText = "Bitbucket repository name")]
+        public string bbRepoName { get; set; }
+        [Option('o', "bbOwner", Required = true, HelpText = "Bitbucket repository owner/organization name")]
+        public string bbRepoOwnerName { get; set; }
+        [Option('u', "bbUser", Required = true, HelpText = "Bitbucket login user name")]
+        public string bbUsername { get; set; }
+        [Option('P', "ghPass", Required = true, HelpText = "GitHub login password")]
+        public string githubPassword { get; set; }
+        [Option('R', "ghRepo", Required = true, HelpText = "GitHub repository name")]
+        public string githubRepoName { get; set; }
+        [Option('O', "ghOwner", Required = true, HelpText = "GitHub repository owner/organization name")]
+        public string githubRepoOwnerName { get; set; }
+        [Option('U', "ghUser", Required = true, HelpText = "GitHub login user name")]
+        public string githubUsername { get; set; }
+        [Option('c',"LabelColor", Default = "fef2c0", HelpText = "Color assigned to the migration label")]
+        public string LabelColor { get; set; }
+        [Option('l',"Label", Default = "bitbucket-migrated", HelpText = "Label applied to migrated issues")]
+        public string LabelName { get; set; }
+        [Option( "ComponentColor", Default = "d4c5f9", HelpText = "Color assigned to migrated Component labels")]
+        public string ComponentColor { get; set; }
+    }
+}

--- a/BitToGithub/Program.cs
+++ b/BitToGithub/Program.cs
@@ -1,145 +1,79 @@
-﻿using Octokit;
+﻿// This file is part of the BitToGithub project
+//
+// Copyright © 2016-2019 Tigra Astronomy, all rights reserved.
+//
+// File: Program.cs  Last modified: 2019-09-06@02:44 by Tim Long
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
 
 namespace BitToGithub
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
-            const string bbUsername = "";
-            const string bbPassword = "";
-            const string bbRepoName = "";
-            const string bbRepoOwnerName = "";
-
-            const string githubUsername = "";
-            const string githubPassword = "";
-            const string githubRepoName = "";
-            const string githubRepoOwnerName = "";
-
-            var isAllDefined = new[] { bbUsername, bbPassword, bbRepoName, githubUsername, githubPassword, githubRepoName, githubRepoOwnerName }.All(param => string.IsNullOrEmpty(param) == false);
-            if (isAllDefined)
-            {
-                string bbRepoIssuesUrl = string.Format("https://api.bitbucket.org/1.0/repositories/{0}/{1}/issues", bbRepoOwnerName, bbRepoName);
-
-                var github = new GitHubClient(new Octokit.ProductHeaderValue("MyAmazingApp"));
-                github.Credentials = new Credentials(githubUsername, githubPassword);
-                var repo = github.Repository.Get(githubRepoOwnerName, githubRepoName).Result;
-
-                using (HttpClient client = new HttpClient())
+            PrintBanner();
+            var commandLineParser = new Parser(with =>
                 {
-                    const string authHeaderRaw = bbUsername + ":" + bbPassword;
-                    const string migratedLabel = "bitbucket-migrated";
-                    AuthenticationHeaderValue authHeader = new AuthenticationHeaderValue("Basic", EncodeToBase64(authHeaderRaw));
-                    client.DefaultRequestHeaders.Authorization = authHeader;
+                    with.CaseSensitive = true;
+                    with.IgnoreUnknownArguments = false;
+                    with.HelpWriter = Console.Out;
+                    with.AutoVersion = true;
+                    with.AutoHelp = true;
+                });
 
-                    // create the migration label.
-                    try
-                    {
-                        github.Issue.Labels.Get(githubRepoOwnerName, githubRepoName, migratedLabel).Wait();
-                    }
-                    catch (Exception ex)
-                    {
-                        // assume that the label is not there. create.
-                        github.Issue.Labels.Create(githubRepoOwnerName, githubRepoName, new NewLabel(migratedLabel, "fef2c0")).Wait();
-                    }
+            var errorMessages = new List<string>();
+            MigrationOptions parsedOptions = null;
 
-                    int startIndex = 1;
-                    while (true)
-                    {
-                        var response = client.GetAsync(bbRepoIssuesUrl + "?start=" + startIndex.ToString()).Result;
-                        response.EnsureSuccessStatusCode();
-                        var result = response.Content.ReadAsAsync<BitBuckect.Rootobject>().Result;
-                        startIndex += result.issues.Length;
-                        if (result.issues.Length > 0)
-                        {
-                            foreach (var issue in result.issues)
-                            {
-                                Console.WriteLine("found issue {0}", issue.local_id);
-                                var newIssue = new NewIssue(issue.title);
-                                newIssue.Labels.Add(migratedLabel);
-
-                                newIssue.Body =
-                                    issue.content +
-                                    Environment.NewLine +
-                                    Environment.NewLine +
-                                    String.Format("> Originally created at {0} (UTC) by {1} as a(n) {2} issue.", issue.utc_created_on, issue.reported_by.username, issue.priority);
-
-                                if (string.IsNullOrWhiteSpace(issue.metadata.component) == false)
-                                {
-                                    // check label
-                                    try
-                                    {
-                                        github.Issue.Labels.Get(githubRepoOwnerName, githubRepoName, issue.metadata.component).Wait();
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        // assume that the label is not there. create.
-                                        Console.WriteLine("Creating label {0}", issue.metadata.component);
-                                        github.Issue.Labels.Create(githubRepoOwnerName, githubRepoName, new NewLabel(issue.metadata.component, "d4c5f9")).Wait();
-                                    }
-
-                                    newIssue.Labels.Add(issue.metadata.component);
-                                }
-
-                                // push the issue to GitHub
-                                Console.WriteLine("Creating issue {0}", issue.local_id);
-                                var createdIssue = github.Issue.Create(githubRepoOwnerName, githubRepoName, newIssue).Result;
-                                Console.WriteLine("Create issue {0} on github.", createdIssue.Number);
-
-                                if (issue.status.Equals("resolved", StringComparison.InvariantCultureIgnoreCase))
-                                {
-                                    Console.WriteLine("Closing issue {0} on github.", createdIssue.Number);
-                                    github.Issue.Update(githubRepoOwnerName, githubRepoName, createdIssue.Number, new IssueUpdate
-                                    {
-                                        State = ItemState.Closed
-                                    }).Wait();
-                                }
-
-                                if (issue.comment_count > 0)
-                                {
-                                    var commentsResponse = client.GetAsync(bbRepoIssuesUrl + "/" + issue.local_id + "/comments").Result;
-
-                                    if (commentsResponse.IsSuccessStatusCode)
-                                    {
-                                        var comments = commentsResponse.Content.ReadAsAsync<IEnumerable<BitBucketComment.Class1>>().Result;
-                                        foreach (var comment in comments)
-                                        {
-                                            Console.WriteLine("Adding comment {0} for github issue {1}.", comment.comment_id, createdIssue.Number);
-                                            github.Issue.Comment.Create(githubRepoOwnerName, githubRepoName, createdIssue.Number, comment.content).Wait();
-                                        }
-                                    }
-                                    else
-                                    {
-                                        Console.WriteLine("Failed to fetch comments for issue {0}", issue.local_id);
-                                    }
-                                }
-                                System.Threading.Thread.Sleep(3000);
-                            }
-                        }
-                        else
-                        {
-                            Console.ReadLine();
-                            break;
-                        }
-                    }
-                }
-            }
-            else
+            try
             {
-                Console.WriteLine("Set all the necessary constant variables.");
+                var result = commandLineParser.ParseArguments<MigrationOptions>(args);
+                result
+                    .WithParsed(options => parsedOptions = options)
+                    .WithNotParsed(errors => errors.ToList().ForEach(e => errorMessages.Add(e.ToString())));
+            }
+            catch (Exception ex)
+            {
+                errorMessages.Add(ex.Message);
+            }
+
+            if (errorMessages.Any())
+                ExitCode.SignalInvalidOptions.WithErrors(errorMessages);
+
+            try
+            {
+                var migrator = new IssueMigrator(parsedOptions);
+                var exitCode = await migrator.Run();
+                exitCode.WithErrors(Enumerable.Empty<string>());
+            }
+            catch (AggregateException ae)
+            {
+                foreach (var innerException in ae.InnerExceptions)
+                {
+                    errorMessages.Add(innerException.Message);
+                }
+                ExitCode.SignalMigrationFailed.WithErrors(errorMessages);
+            }
+            catch (HttpRequestException e)
+            {
+                errorMessages.Add($"Bitbucket error: {e.Message}");
+                ExitCode.SignalMigrationFailed.WithErrors(errorMessages);
+            }
+            catch (Exception e)
+            {
+                errorMessages.Add(e.Message);
+                ExitCode.SignalMigrationFailed.WithErrors(errorMessages);
             }
         }
 
-        private static string EncodeToBase64(string value)
+        private static void PrintBanner()
         {
-            byte[] toEncodeAsBytes = Encoding.UTF8.GetBytes(value);
-            return Convert.ToBase64String(toEncodeAsBytes);
+            Console.WriteLine("Bitbucket to GitHub Issue Migrator");
         }
     }
 }

--- a/BitToGithub/packages.config
+++ b/BitToGithub/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="2.6.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net453" />
   <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net453" />
   <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net453" />


### PR DESCRIPTION
- Added command line options based on CommandLine NuGet package
- Updated to use Bitbucket API 2.0, which has different data models and different pagination.
- Restructured the code to better work with paged datasets and command line options.

I was going to just do a quick add of some command line options, but then I ran into the fact that Bitbucket API 1.0 has been retired, so had to update to use API 2.0, which meant re-doing the data models and how pagination is handled. I ended up doing a pretty extensive refactor. I'm not sure whether this is appropriate for a pull request, but I'll throw it out there and leave it up to you whether you want to take it back into your original repo.